### PR TITLE
ci: publish the gem via RubyGems trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Push the version tag when `rake release` creates one.
+      contents: write
+      # Mint the OIDC token RubyGems trusted publishing authenticates with.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - run: bundle exec rspec
+
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary

Releasing currently means building the gem locally and pushing it with a personal API key. The account's MFA level is **UI and API**, so every push also needs a manual OTP — which is what blocked the 1.1.0 release.

This publishes from GitHub Actions instead. [`rubygems/release-gem`](https://github.com/rubygems/release-gem) mints an OIDC token that RubyGems exchanges for a short-lived scoped credential: no API key stored anywhere, no OTP.

## How it works

- Triggers on a **published GitHub release** (plus `workflow_dispatch` for manual runs).
- Runs `bundle exec rspec` first, so a red build cannot reach RubyGems.
- `rubygems/release-gem@v1` runs `bundle exec rake release`. At release-published time the tag already exists, and bundler's `release:source_control_push` task is a no-op when `already_tagged?` is true — so it only builds and pushes the gem.
- `id-token: write` mints the OIDC token; `contents: write` covers the tag push on the `workflow_dispatch` path where the tag does not exist yet.

## Setup required before this works

On RubyGems.org → Settings → **Pending Trusted Publishers** → Add, register:

| field | value |
|---|---|
| Repository owner | `Halvanhelv` |
| Repository name | `deepl_diff` |
| Workflow filename | `release.yml` |
| Environment | *leave blank* |

## Test plan

Once the trusted publisher is registered, re-run the workflow against the existing `v1.1.0` release (Actions → Release → Run workflow, or re-publish the release). It should build `pkg/deepl_diff-1.1.0.gem` and push it without any credential prompt.

https://claude.ai/code/session_01Pda49PcgziFVnibkKKjXRE