### PR TITLE
chore: release version 1.1.1

### DIFF
--- a/lib/deepl_diff/version.rb
+++ b/lib/deepl_diff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeepLDiff
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
## Summary

Bumps the version to 1.1.1.

`lib/` is untouched since 1.1.0 — this is a patch release that picks up the Minitest migration (#3), which swaps the `rspec` development dependency for `minitest` and rewrites the `Rakefile`. Both ship inside the gem, so they warrant a version.

## Test plan

- `bundle exec rake test` — 28 runs, 34 assertions, 0 failures.
- Merging this and publishing the `v1.1.1` release triggers `release.yml`, which pushes to RubyGems via trusted publishing.

https://claude.ai/code/session_01Pda49PcgziFVnibkKKjXRE