### PR TITLE
refactor!: drop six runtime dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,5 +24,6 @@ Gemspec/DevelopmentDependencies:
 Metrics/ClassLength:
   Exclude:
     - lib/deepl_diff/tokenizer.rb
+    - lib/deepl_diff/request.rb
     # Test classes are mostly tables of cases.
     - test/**/*

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ If your user changes a single word within the long description, you will be char
 
 Much better approach is to try to translate every repeated structural element (sentence) in your texts array just once to save money. This gem helps to make it done.
 
+## Dependencies
+
+This gem loads two: [`ox`](https://github.com/ohler55/ox) to walk the HTML, and
+[`punkt-segmenter`](https://github.com/lfcipriani/punkt-segmenter) to split text
+into sentences.
+
+Everything else is duck typed and supplied by you: `DeepLDiff.api` is anything
+answering to `#translate`, and both `RedisCacheStore` and `RedisRateLimiter`
+take anything answering to `#with`. Bring your own client, pool and store.
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -38,11 +48,14 @@ Or install it yourself as:
 ```ruby
 require "deepl_diff"
 
-# This dependencies are not included, as you might need to roll your own cache based on different store
+# None of these are dependencies of this gem. It loads only `ox` and
+# `punkt-segmenter`; the API client, the connection pool, and whatever backs
+# the cache and the rate limiter are yours to choose and to require.
+require "deepl"
 require "redis"
 require "connection_pool"
 require "redis-namespace"
-require "ratelimit" # Optional, if you will use
+require "ratelimit" # Optional, only if you use the rate limiter
 
 # Setup https://github.com/wikiti/deepl-rb
 DeepL.configure do |config|
@@ -108,10 +121,10 @@ DeepL API has a limitation: query can not be longer than approximately 128 KB. I
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/wikiti/deepl-rb.
+Bug reports and pull requests are welcome on GitHub at https://github.com/Halvanhelv/deepl_diff.

--- a/deepl_diff.gemspec
+++ b/deepl_diff.gemspec
@@ -45,12 +45,9 @@ between revisions of long texts.
   spec.add_development_dependency "rubocop", "~> 1.90"
   spec.add_development_dependency "simplecov", "~> 1.2"
 
-  spec.add_dependency "connection_pool", ">= 2.4", "< 4.0"
-  spec.add_dependency "deepl-rb", "~> 3.9"
-  spec.add_dependency "dry-initializer", "~> 3.2"
+  # The only two gems this one loads. Everything else -- the DeepL client, the
+  # connection pool, and whatever backs the cache and the rate limiter -- is
+  # supplied by the application and duck typed, so it stays out of the gemspec.
   spec.add_dependency "ox", "~> 2.14"
   spec.add_dependency "punkt-segmenter", "~> 0.9"
-  spec.add_dependency "ratelimit", "~> 1.1"
-  spec.add_dependency "redis", ">= 5.0", "< 7.0"
-  spec.add_dependency "redis-namespace", "~> 1.11"
 end

--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -7,8 +7,6 @@ require "stringio"
 
 require "ox"
 require "punkt-segmenter"
-require "dry/initializer"
-require "deepl"
 
 require "deepl_diff/version"
 require "deepl_diff/tokenizer"

--- a/lib/deepl_diff/cache.rb
+++ b/lib/deepl_diff/cache.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class DeepLDiff::Cache
-  extend Dry::Initializer
-
-  param :from
-  param :to
+  def initialize(from, to)
+    @from = from
+    @to = to
+  end
 
   def cached_and_missing(values)
     keys = values.map { |v| key(v) }
@@ -21,6 +21,8 @@ class DeepLDiff::Cache
   end
 
   private
+
+  attr_reader :from, :to
 
   def store_value(value, translation)
     cache_store.write(key(value), translation)

--- a/lib/deepl_diff/chunker.rb
+++ b/lib/deepl_diff/chunker.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DeepLDiff::Chunker
-  extend ::Dry::Initializer
-
   class Error < StandardError; end
 
   Chunk = Struct.new(:texts, :bytesize)
@@ -10,9 +8,11 @@ class DeepLDiff::Chunker
   MAX_CHUNK_SIZE = 1700
   COUNT_LIMIT = 300
 
-  param :values
-  option :limit, default: proc { MAX_CHUNK_SIZE }
-  option :count_limit, default: proc { COUNT_LIMIT }
+  def initialize(values, limit: MAX_CHUNK_SIZE, count_limit: COUNT_LIMIT)
+    @values = values
+    @limit = limit
+    @count_limit = count_limit
+  end
 
   def call
     chunks.map(&:texts)
@@ -34,6 +34,8 @@ class DeepLDiff::Chunker
   end
 
   private
+
+  attr_reader :values, :limit, :count_limit
 
   def next_chunk?(tail, value)
     tail.nil? ||

--- a/lib/deepl_diff/redis_cache_store.rb
+++ b/lib/deepl_diff/redis_cache_store.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class DeepLDiff::RedisCacheStore
-  extend Dry::Initializer
+  ONE_WEEK = 60 * 60 * 24 * 7
 
-  param :connection_pool
-
-  option :timeout, default: proc { 60 * 60 * 24 * 7 }
-  option :namespace, default: proc { DeepLDiff::CACHE_NAMESPACE }
+  # `connection_pool` is anything answering to #with, and what it yields is
+  # anything Redis::Namespace accepts. Neither gem is a dependency of this one.
+  def initialize(connection_pool, timeout: ONE_WEEK, namespace: DeepLDiff::CACHE_NAMESPACE)
+    @connection_pool = connection_pool
+    @timeout = timeout
+    @namespace = namespace
+  end
 
   def read_multi(keys)
     redis { |redis| redis.mget(*keys) }
@@ -17,6 +20,8 @@ class DeepLDiff::RedisCacheStore
   end
 
   private
+
+  attr_reader :connection_pool, :timeout, :namespace
 
   def redis
     connection_pool.with do |redis|

--- a/lib/deepl_diff/redis_rate_limiter.rb
+++ b/lib/deepl_diff/redis_rate_limiter.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
 class DeepLDiff::RedisRateLimiter
-  extend Dry::Initializer
-
   class RateLimitExceeded < StandardError; end
 
-  param :connection_pool
-  param :threshold, default: proc { 8000 }
-  param :interval,  default: proc { 60 }
+  DEFAULT_THRESHOLD = 8000
+  DEFAULT_INTERVAL = 60
 
-  option :namespace, default: proc { DeepLDiff::CACHE_NAMESPACE }
+  # `connection_pool` is anything answering to #with, and what it yields is
+  # anything Ratelimit accepts. Neither gem is a dependency of this one.
+  def initialize(connection_pool,
+                 threshold: DEFAULT_THRESHOLD,
+                 interval: DEFAULT_INTERVAL,
+                 namespace: DeepLDiff::CACHE_NAMESPACE)
+    @connection_pool = connection_pool
+    @threshold = threshold
+    @interval = interval
+    @namespace = namespace
+  end
 
   def check(size)
     connection_pool.with do |redis|
@@ -19,4 +26,8 @@ class DeepLDiff::RedisRateLimiter
       rate_limit.add size
     end
   end
+
+  private
+
+  attr_reader :connection_pool, :threshold, :interval, :namespace
 end

--- a/lib/deepl_diff/request.rb
+++ b/lib/deepl_diff/request.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class DeepLDiff::Request
-  extend Dry::Initializer
   extend Forwardable
-
-  param :values
-  param :options
 
   def_delegators :DeepLDiff, :api, :cache_store, :rate_limiter
   def_delegators :"DeepLDiff::Linearizer", :linearize, :restore
+
+  def initialize(values, options)
+    @values = values
+    @options = options
+  end
 
   def call
     validate_globals
@@ -19,6 +20,8 @@ class DeepLDiff::Request
   end
 
   private
+
+  attr_reader :values, :options
 
   def from
     @from ||= options.delete(:from) || detect_language

--- a/lib/deepl_diff/version.rb
+++ b/lib/deepl_diff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeepLDiff
-  VERSION = "1.1.1"
+  VERSION = "2.0.0"
 end

--- a/test/deepl_diff/redis_cache_store_test.rb
+++ b/test/deepl_diff/redis_cache_store_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The gem depends on neither redis nor redis-namespace -- it just calls into
+# whatever the application supplies. This stand-in applies the namespace the
+# way redis-namespace does, so the keys reaching Redis can be asserted on.
+module Redis; end
+
+class Redis::Namespace
+  def initialize(namespace, redis:)
+    @namespace = namespace
+    @redis = redis
+  end
+
+  def mget(*keys)
+    @redis.mget(*keys.map { |key| "#{@namespace}:#{key}" })
+  end
+
+  def setex(key, timeout, value)
+    @redis.setex("#{@namespace}:#{key}", timeout, value)
+  end
+end
+
+class RedisCacheStoreTest < Minitest::Test
+  class FakeRedis
+    attr_reader :calls
+
+    def initialize(values = [])
+      @values = values
+      @calls = []
+    end
+
+    def mget(*keys)
+      @calls << [:mget, keys]
+      @values
+    end
+
+    def setex(key, timeout, value)
+      @calls << [:setex, key, timeout, value]
+      "OK"
+    end
+  end
+
+  def test_read_multi_namespaces_the_keys
+    redis = FakeRedis.new(%w[one two])
+
+    assert_equal %w[one two], store(redis).read_multi(%w[a b])
+    assert_equal [[:mget, %w[deepl-diff:a deepl-diff:b]]], redis.calls
+  end
+
+  def test_write_expires_after_a_week_by_default
+    redis = FakeRedis.new
+
+    store(redis).write("a", "b")
+
+    assert_equal [[:setex, "deepl-diff:a", 604_800, "b"]], redis.calls
+  end
+
+  def test_write_honours_a_custom_timeout_and_namespace
+    redis = FakeRedis.new
+
+    store(redis, timeout: 60, namespace: "t").write("a", "b")
+
+    assert_equal [[:setex, "t:a", 60, "b"]], redis.calls
+  end
+
+  private
+
+  def store(redis, **)
+    DeepLDiff::RedisCacheStore.new(FakeConnectionPool.new(redis), **)
+  end
+end

--- a/test/deepl_diff/redis_rate_limiter_test.rb
+++ b/test/deepl_diff/redis_rate_limiter_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The gem does not depend on the ratelimit gem -- it only constructs whatever
+# Ratelimit resolves to. This stand-in records onto the connection it is given,
+# which is the only handle the test has on the object built inside #check.
+class Ratelimit
+  def initialize(namespace, redis:)
+    @namespace = namespace
+    @redis = redis
+  end
+
+  def exceeded?(subject, threshold:, interval:)
+    @redis.checks << [@namespace, subject, threshold, interval]
+    @redis.exceeded
+  end
+
+  def add(size)
+    @redis.added << size
+  end
+end
+
+class RedisRateLimiterTest < Minitest::Test
+  class FakeRedis
+    attr_reader :checks, :added, :exceeded
+
+    def initialize(exceeded: false)
+      @exceeded = exceeded
+      @checks = []
+      @added = []
+    end
+  end
+
+  def test_check_uses_the_default_threshold_and_interval
+    redis = FakeRedis.new
+
+    limiter(redis).check(120)
+
+    assert_equal [["deepl-diff", "call", 8000, 60]], redis.checks
+    assert_equal [120], redis.added
+  end
+
+  # Regression test: these used to be positional, so the documented keyword
+  # call silently fell back to the defaults.
+  def test_check_honours_a_custom_threshold_interval_and_namespace
+    redis = FakeRedis.new
+
+    limiter(redis, threshold: 999, interval: 7, namespace: "t").check(1)
+
+    assert_equal [["t", "call", 999, 7]], redis.checks
+  end
+
+  def test_check_raises_once_the_threshold_is_passed
+    redis = FakeRedis.new(exceeded: true)
+
+    assert_raises(DeepLDiff::RedisRateLimiter::RateLimitExceeded) do
+      limiter(redis).check(1)
+    end
+    assert_empty redis.added
+  end
+
+  private
+
+  def limiter(redis, **)
+    DeepLDiff::RedisRateLimiter.new(FakeConnectionPool.new(redis), **)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,15 @@ SimpleCov.start
 require "deepl_diff"
 
 require "minitest/autorun"
+
+# Stands in for a connection_pool. The gem only ever calls #with on whatever
+# it is handed, so this is the whole contract.
+class FakeConnectionPool
+  def initialize(connection)
+    @connection = connection
+  end
+
+  def with
+    yield @connection
+  end
+end


### PR DESCRIPTION
## Summary

The gemspec declared **eight** runtime dependencies. Six of them are never loaded by this gem. After this change it loads two: `ox` and `punkt-segmenter`.

That is what the README promised all along — *"This dependencies are not included, as you might need to roll your own cache based on different store"* — the gemspec just never agreed with it.

## What was actually used

| gem | where its constant appears in `lib/` | verdict |
|---|---|---|
| `ox` | `Ox::Sax`, `Ox.sax_parse` in the tokenizer | **kept** |
| `punkt-segmenter` | `Punkt::SentenceTokenizer` in the tokenizer | **kept** |
| `dry-initializer` | five `extend` lines | dropped |
| `connection_pool` | nowhere — the pool is duck typed on `#with` | dropped |
| `redis` | nowhere — bare `Redis` is never named | dropped |
| `deepl-rb` | nowhere — `require "deepl"` at load, constant unused | dropped |
| `redis-namespace` | inside one method body of `RedisCacheStore` | dropped |
| `ratelimit` | inside one method body of `RedisRateLimiter` | dropped |

The last two already resolved lazily: they are named inside method bodies, so the gem loaded fine without them and only broke if you actually used those classes. Declaring them as hard runtime dependencies forced them on everyone who used their own cache store.

## dry-initializer → plain Ruby

`Dry::Initializer` generated **private** readers, so replacing them with a private `attr_reader` keeps the public API byte-for-byte identical:

```ruby
# before
extend Dry::Initializer
param :values
option :limit, default: proc { MAX_CHUNK_SIZE }

# after
def initialize(values, limit: MAX_CHUNK_SIZE, count_limit: COUNT_LIMIT)
  @values = values
  @limit = limit
  @count_limit = count_limit
end

private

attr_reader :values, :limit, :count_limit
```

## Bug fixed on the way

`RedisRateLimiter` declared `threshold` and `interval` as **positional** `param`s, so the keyword call the README documents silently discarded them:

```ruby
RedisRateLimiter.new(pool, threshold: 999, interval: 7)
#=> threshold 8000, interval 60
```

They are keywords now, matching `RedisCacheStore`. There is a regression test.

## Tests

Both Redis wrappers had **no tests at all**. They have them now — 6 new cases. The stand-ins they use for `Redis::Namespace`, `Ratelimit` and the connection pool double as an executable statement of the duck types this gem expects.

Coverage: 94.68% → **97.57%** (282/289).

## Breaking changes → 2.0.0

- Applications relying on this gem to install the DeepL client, `redis`, `redis-namespace`, `connection_pool` or `ratelimit` must depend on them directly. The README now says so explicitly and its example requires `deepl`.
- Callers passing `threshold`/`interval` to `RedisRateLimiter` positionally must switch to keywords.

## Test plan

- `bundle exec rake test` — 34 runs, 44 assertions, 0 failures, on Ruby 4.0.5 and 3.2.4.
- `bundle exec rubocop` — 0 offenses.
- `Gemfile.lock` re-resolved: zero matches for `dry-initializer`, `deepl-rb`, `redis`, `connection_pool`, `ratelimit`. With none of them installed, `require "deepl_diff"` loads and `DeepLDiff::Tokenizer.tokenize("<b>hi</b>")` returns the expected tokens.

https://claude.ai/code/session_01Pda49PcgziFVnibkKKjXRE