### PR TITLE
chore: release version 2.2.0

### DIFF
--- a/deepl_diff.gemspec
+++ b/deepl_diff.gemspec
@@ -33,6 +33,15 @@ between revisions of long texts.
           "public gem pushes."
   end
 
+  spec.post_install_message = <<~MESSAGE
+    deepl_diff is being replaced by translation_diff, which supports
+    translation providers other than DeepL.
+
+    This version of deepl_diff keeps working and will not change again.
+
+    https://rubygems.org/gems/translation_diff
+  MESSAGE
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/lib/deepl_diff/version.rb
+++ b/lib/deepl_diff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeepLDiff
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
Message-only release. No code changes.

`deepl_diff` is being replaced by `translation_diff`, which supports translation providers other than DeepL. This adds a post-install message pointing there and bumps the version.

This has to ship **before** the rename: once the gemspec carries the new name, `deepl_diff` can no longer be published from this repository. It also has to ship before the breaking changes land, so that 2.2.0 stays safe for anyone who upgrades into it.

## Changes

- `deepl_diff.gemspec` — adds `post_install_message`
- `lib/deepl_diff/version.rb` — 2.1.0 → 2.2.0

## Test plan

- `bundle exec rake test` — 46 runs, 44 assertions, 0 failures
- `bundle exec rubocop` — no offences
- `git diff --stat` confirms exactly two files touched and no code among them