### PR TITLE
refactor!: introduce the adapter contract

### DIFF
--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -26,8 +26,8 @@ module DeepLDiff
   class << self
     attr_accessor :api, :cache_store, :rate_limiter
 
-    def translate(values, **)
-      Request.new(values, **).call
+    def translate(values, from: nil, to: nil, **)
+      Request.new(values, from: from, to: to, **).call
     end
   end
 

--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -12,6 +12,7 @@ require "deepl_diff/version"
 
 require "deepl_diff/adapters"
 require "deepl_diff/adapters/null"
+require "deepl_diff/adapters/deepl"
 require "deepl_diff/tokenizer"
 require "deepl_diff/linearizer"
 require "deepl_diff/chunker"

--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -9,6 +9,10 @@ require "ox"
 require "punkt-segmenter"
 
 require "deepl_diff/version"
+
+module DeepLDiff::Adapters; end
+
+require "deepl_diff/adapters/null"
 require "deepl_diff/tokenizer"
 require "deepl_diff/linearizer"
 require "deepl_diff/chunker"
@@ -18,6 +22,7 @@ require "deepl_diff/redis_cache_store"
 require "deepl_diff/redis_rate_limiter"
 require "deepl_diff/request"
 
+# rubocop:disable-next Style/OneClassPerFile
 module DeepLDiff
   class << self
     attr_accessor :api, :cache_store, :rate_limiter

--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -26,8 +26,8 @@ module DeepLDiff
   class << self
     attr_accessor :api, :cache_store, :rate_limiter
 
-    def translate(*)
-      Request.new(*).call
+    def translate(values, **)
+      Request.new(values, **).call
     end
   end
 

--- a/lib/deepl_diff.rb
+++ b/lib/deepl_diff.rb
@@ -10,8 +10,7 @@ require "punkt-segmenter"
 
 require "deepl_diff/version"
 
-module DeepLDiff::Adapters; end
-
+require "deepl_diff/adapters"
 require "deepl_diff/adapters/null"
 require "deepl_diff/tokenizer"
 require "deepl_diff/linearizer"
@@ -22,7 +21,6 @@ require "deepl_diff/redis_cache_store"
 require "deepl_diff/redis_rate_limiter"
 require "deepl_diff/request"
 
-# rubocop:disable-next Style/OneClassPerFile
 module DeepLDiff
   class << self
     attr_accessor :api, :cache_store, :rate_limiter

--- a/lib/deepl_diff/adapters.rb
+++ b/lib/deepl_diff/adapters.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+module DeepLDiff::Adapters; end

--- a/lib/deepl_diff/adapters/deepl.rb
+++ b/lib/deepl_diff/adapters/deepl.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Wraps a deepl-rb client. That gem is not a dependency of this one: the
+# client arrives as an argument and the ::DeepL default resolves at call
+# time, so an application that never uses this adapter never needs it.
+class DeepLDiff::Adapters::DeepL
+  # DeepL requires a target language even when only the detection is
+  # wanted, so the adapter picks one rather than making the caller do it.
+  DETECTION_TARGET = "EN"
+
+  MAX_REQUEST_SIZE = 1700
+  MAX_BATCH_SIZE = 300
+
+  def initialize(client = ::DeepL)
+    @client = client
+  end
+
+  def translate(texts, from:, to:, **options)
+    Array(@client.translate(texts, from, to, options)).map(&:text)
+  end
+
+  def detect(text)
+    @client.translate(text, nil, DETECTION_TARGET)
+           .detected_source_language
+           .downcase
+  end
+
+  def max_request_size = MAX_REQUEST_SIZE
+  def max_batch_size = MAX_BATCH_SIZE
+  def cache_key = "deepl"
+
+  private
+
+  attr_reader :client
+end

--- a/lib/deepl_diff/adapters/null.rb
+++ b/lib/deepl_diff/adapters/null.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Hands back what it was given. For tests, and for wiring a pipeline up
+# before a real provider is available.
+class DeepLDiff::Adapters::Null
+  # No #detect on purpose: detection is optional in the contract, and this
+  # is the adapter that proves the optional branch works.
+  # rubocop:disable-next Lint/UnusedMethodArgument
+  def translate(texts, from:, to:, **options)
+    texts.map(&:to_s)
+  end
+
+  def max_request_size = 1_000_000
+  def max_batch_size = 1_000_000
+  def cache_key = "null"
+end

--- a/lib/deepl_diff/cache.rb
+++ b/lib/deepl_diff/cache.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class DeepLDiff::Cache
+  class Error < StandardError; end
+
+  # An application uses a handful of distinct option sets, so 32 bits of
+  # digest is ample to keep them apart; the full 128-bit MD5 would just
+  # bloat every key in a cache that may hold millions of them.
   DIGEST_LENGTH = 8
 
   def initialize(from, to, provider:, options: {})
@@ -40,7 +45,9 @@ class DeepLDiff::Cache
   end
 
   # "EN" and :en are the same language; without this they are two entries
-  # for identical work.
+  # for identical work. The collision argument for #key depends on none of
+  # its segments containing a colon: from/to are caller-supplied, so this
+  # normalisation must not introduce one.
   def language(code)
     code.to_s.downcase
   end
@@ -50,12 +57,20 @@ class DeepLDiff::Cache
   def options_digest
     return @options_digest if defined?(@options_digest)
 
-    @options_digest =
-      if options.empty?
-        nil
-      else
-        Digest::MD5.hexdigest(options.sort_by { |key, _| key.to_s }.inspect)[0, DIGEST_LENGTH]
-      end
+    @options_digest = options.empty? ? nil : Digest::MD5.hexdigest(canonical(options))[0, DIGEST_LENGTH]
+  end
+
+  # Object#inspect is not a stable serialisation: Ruby 3.4 changed how
+  # symbol-keyed hashes render, and an object without its own #inspect embeds
+  # a memory address. Either would silently change every cache key and make
+  # the application pay for every translation a second time.
+  def canonical(value)
+    case value
+    when Hash then value.sort_by { |key, _| key.to_s }.map { |key, item| "#{key}=#{canonical(item)}" }.join(",")
+    when Array then value.map { |item| canonical(item) }.join(",")
+    when String, Symbol, Numeric, true, false, nil then value.inspect
+    else raise Error, "Cannot build a stable cache key from #{value.class} in the provider options"
+    end
   end
 
   def cache_store

--- a/lib/deepl_diff/cache.rb
+++ b/lib/deepl_diff/cache.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class DeepLDiff::Cache
-  def initialize(from, to)
+  DIGEST_LENGTH = 8
+
+  def initialize(from, to, provider:, options: {})
     @from = from
     @to = to
+    @provider = provider
+    @options = options
   end
 
   def cached_and_missing(values)
@@ -22,7 +26,7 @@ class DeepLDiff::Cache
 
   private
 
-  attr_reader :from, :to
+  attr_reader :from, :to, :provider, :options
 
   def store_value(value, translation)
     cache_store.write(key(value), translation)
@@ -31,7 +35,27 @@ class DeepLDiff::Cache
 
   def key(value)
     hash = Digest::MD5.hexdigest(value.strip) # No matter how much spaces
-    "#{from}:#{to}:#{hash}"
+
+    [provider, language(from), language(to), options_digest, hash].compact.join(":")
+  end
+
+  # "EN" and :en are the same language; without this they are two entries
+  # for identical work.
+  def language(code)
+    code.to_s.downcase
+  end
+
+  # Two calls differing only in formality or glossary are two different
+  # translations and must not share a key.
+  def options_digest
+    return @options_digest if defined?(@options_digest)
+
+    @options_digest =
+      if options.empty?
+        nil
+      else
+        Digest::MD5.hexdigest(options.sort_by { |key, _| key.to_s }.inspect)[0, DIGEST_LENGTH]
+      end
   end
 
   def cache_store

--- a/lib/deepl_diff/chunker.rb
+++ b/lib/deepl_diff/chunker.rb
@@ -5,10 +5,10 @@ class DeepLDiff::Chunker
 
   Chunk = Struct.new(:texts, :escaped_size)
 
-  MAX_CHUNK_SIZE = 1700
-  COUNT_LIMIT = 300
-
-  def initialize(values, limit: MAX_CHUNK_SIZE, count_limit: COUNT_LIMIT)
+  # No defaults. With one provider a default looks meaningful; with two it
+  # silently lies about the second, which is the class of bug this file
+  # already had once.
+  def initialize(values, limit:, count_limit:)
     @values = values
     @limit = limit
     @count_limit = count_limit

--- a/lib/deepl_diff/request.rb
+++ b/lib/deepl_diff/request.rb
@@ -8,11 +8,11 @@ class DeepLDiff::Request
   def_delegators :DeepLDiff, :api, :cache_store, :rate_limiter
   def_delegators :"DeepLDiff::Linearizer", :linearize, :restore
 
-  def initialize(values, options)
+  def initialize(values, from: nil, to: nil, **options)
     @values = values
-    # #from and #to consume their keys so the rest can go to the API as-is.
-    # Copy first: the caller's hash is theirs, and it is often frozen.
-    @options = options.dup
+    @from = from
+    @to = to
+    @options = options
   end
 
   def call
@@ -25,14 +25,10 @@ class DeepLDiff::Request
 
   private
 
-  attr_reader :values, :options
+  attr_reader :values, :options, :to
 
   def from
-    @from ||= options.delete(:from) || detect_language
-  end
-
-  def to
-    @to ||= options.delete(:to) { nil }
+    @from ||= detect_language
   end
 
   # A detected language arrives as a String while :to is usually a Symbol, so

--- a/lib/deepl_diff/request.rb
+++ b/lib/deepl_diff/request.rb
@@ -100,7 +100,11 @@ class DeepLDiff::Request
   # (groups less 2k sym)
   # => [[ ..., "Good", "Boy", ... ]]
   def chunks
-    @chunks ||= DeepLDiff::Chunker.new(text_tokens_texts).call
+    @chunks ||= DeepLDiff::Chunker.new(
+      text_tokens_texts,
+      limit: api.max_request_size,
+      count_limit: api.max_batch_size
+    ).call
   end
 
   # Translates/loads from cache values from each chunk

--- a/lib/deepl_diff/request.rb
+++ b/lib/deepl_diff/request.rb
@@ -171,7 +171,7 @@ class DeepLDiff::Request
   end
 
   def cache
-    @cache ||= DeepLDiff::Cache.new(from, to)
+    @cache ||= DeepLDiff::Cache.new(from, to, provider: api.cache_key, options: options)
   end
 
   def check_rate_limit(values)

--- a/lib/deepl_diff/request.rb
+++ b/lib/deepl_diff/request.rb
@@ -45,8 +45,9 @@ class DeepLDiff::Request
   end
 
   def detect_language
-    api.translate(text_tokens_texts.join(" ")[0..100], nil, to)
-       .detected_source_language.downcase
+    raise Error, "Pass from: -- #{api.class} cannot detect the source language" unless api.respond_to?(:detect)
+
+    api.detect(text_tokens_texts.join(" ")[0..100])
   end
 
   def validate_globals
@@ -160,13 +161,13 @@ class DeepLDiff::Request
 
   def call_api(values)
     check_rate_limit(values)
-    translations = [api.translate(values, from, to, options)].flatten.map(&:text)
+    translations = api.translate(values, from: from, to: to, **options)
     return translations if translations.size == values.size
 
     # Letting a short response through means shifting nils into the results,
     # which surfaces much later as a NoMethodError far from the cause.
     raise Error,
-          "API returned #{translations.size} translations for #{values.size} values"
+          "Adapter returned #{translations.size} translations for #{values.size} values"
   end
 
   def cache

--- a/test/deepl_diff/adapters/deepl_test.rb
+++ b/test/deepl_diff/adapters/deepl_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/adapter_contract"
+
+class DeepLAdapterTest < Minitest::Test
+  include AdapterContract
+
+  Translation = Struct.new(:text)
+  Detection = Struct.new(:detected_source_language)
+
+  # Stands in for the deepl-rb client. The gem does not depend on it.
+  class FakeClient
+    attr_reader :calls
+
+    def initialize(detected: "DE")
+      @detected = detected
+      @calls = []
+    end
+
+    def translate(text, from, to, options = {})
+      @calls << [text, from, to, options]
+      return Detection.new(@detected) if from.nil?
+
+      Array(text).map { |value| Translation.new("T:#{value}") }
+    end
+  end
+
+  def adapter(client = FakeClient.new)
+    DeepLDiff::Adapters::DeepL.new(client)
+  end
+
+  def test_translate_unwraps_the_text_of_each_result
+    assert_equal %w[T:one T:two], adapter.translate(%w[one two], from: :en, to: :ru)
+  end
+
+  def test_translate_passes_provider_options_through
+    client = FakeClient.new
+
+    adapter(client).translate(%w[one], from: :en, to: :ru, formality: :less)
+
+    assert_equal [[%w[one], :en, :ru, { formality: :less }]], client.calls
+  end
+
+  def test_detect_downcases_the_language
+    assert_equal "de", adapter(FakeClient.new(detected: "DE")).detect("etwas")
+  end
+
+  # DeepL has no detection endpoint, so the adapter supplies a target of its
+  # own rather than making the caller invent one.
+  def test_detect_supplies_its_own_target_language
+    client = FakeClient.new
+
+    adapter(client).detect("etwas")
+
+    assert_equal [["etwas", nil, "EN", {}]], client.calls
+  end
+
+  def test_cache_key_identifies_the_provider
+    assert_equal "deepl", adapter.cache_key
+  end
+end

--- a/test/deepl_diff/adapters/null_test.rb
+++ b/test/deepl_diff/adapters/null_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/adapter_contract"
+
+class NullAdapterTest < Minitest::Test
+  include AdapterContract
+
+  def adapter
+    DeepLDiff::Adapters::Null.new
+  end
+
+  def test_translate_returns_the_input_unchanged
+    assert_equal %w[one two], adapter.translate(%w[one two], from: :en, to: :ru)
+  end
+end

--- a/test/deepl_diff/cache_test.rb
+++ b/test/deepl_diff/cache_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CacheTest < Minitest::Test
+  class RecordingStore
+    attr_reader :keys
+
+    def initialize
+      @keys = []
+    end
+
+    def read_multi(keys)
+      @keys.concat(keys)
+      [nil] * keys.size
+    end
+
+    def write(_key, value)
+      value
+    end
+  end
+
+  def setup
+    @store = RecordingStore.new
+    DeepLDiff.cache_store = @store
+  end
+
+  def teardown
+    DeepLDiff.cache_store = nil
+  end
+
+  # Two providers writing to one store used to collide: switching DeepL for
+  # another provider silently returned DeepL's translations.
+  def test_the_provider_is_part_of_the_key
+    key_for(provider: "deepl")
+    key_for(provider: "google")
+
+    refute_equal @store.keys[0], @store.keys[1]
+  end
+
+  # formality: :less used to share a key with the default, so whichever
+  # translated first won.
+  def test_the_provider_options_are_part_of_the_key
+    key_for(options: {})
+    key_for(options: { formality: :less })
+
+    refute_equal @store.keys[0], @store.keys[1]
+  end
+
+  def test_the_options_digest_is_order_independent
+    key_for(options: { a: 1, b: 2 })
+    key_for(options: { b: 2, a: 1 })
+
+    assert_equal @store.keys[0], @store.keys[1]
+  end
+
+  # "EN" and :en are the same language and used to produce two entries for
+  # identical work.
+  def test_the_language_codes_are_normalised
+    key_for(from: "EN", to: "RU")
+    key_for(from: :en, to: :ru)
+
+    assert_equal @store.keys[0], @store.keys[1]
+  end
+
+  def test_leading_and_trailing_space_does_not_change_the_key
+    key_for(value: "text")
+    key_for(value: "  text  ")
+
+    assert_equal @store.keys[0], @store.keys[1]
+  end
+
+  private
+
+  def key_for(value: "text", from: :en, to: :ru, provider: "deepl", options: {})
+    DeepLDiff::Cache.new(from, to, provider: provider, options: options)
+                    .cached_and_missing([value])
+  end
+end

--- a/test/deepl_diff/cache_test.rb
+++ b/test/deepl_diff/cache_test.rb
@@ -20,6 +20,19 @@ class CacheTest < Minitest::Test
     end
   end
 
+  # A store that answers with fixed, caller-chosen results regardless of the
+  # keys it is asked about, to pin the positional contract between the keys
+  # sent and the results read back.
+  class PositionalStore
+    def initialize(responses)
+      @responses = responses
+    end
+
+    def read_multi(_keys)
+      @responses
+    end
+  end
+
   def setup
     @store = RecordingStore.new
     DeepLDiff.cache_store = @store
@@ -68,6 +81,35 @@ class CacheTest < Minitest::Test
     key_for(value: "  text  ")
 
     assert_equal @store.keys[0], @store.keys[1]
+  end
+
+  # nil and "" are different values; #to_s would collide them, so the digest
+  # must be built from a serialisation that keeps them apart.
+  def test_nil_and_empty_string_option_values_produce_different_keys
+    key_for(options: { a: nil })
+    key_for(options: { a: "" })
+
+    refute_equal @store.keys[0], @store.keys[1]
+  end
+
+  # An option value with no stable serialisation (no #inspect of its own,
+  # or one that embeds a memory address) must not be allowed to silently
+  # produce an unreproducible cache key.
+  def test_an_unsupported_option_value_raises
+    assert_raises(DeepLDiff::Cache::Error) { key_for(options: { a: Object.new }) }
+  end
+
+  # cached_and_missing pairs the store's response with the requested values
+  # by position, trusting the store to return results in key order. A
+  # database-backed store answering `WHERE key IN (...)` will not.
+  def test_cached_and_missing_pairs_results_positionally
+    DeepLDiff.cache_store = PositionalStore.new(["cached one", nil, "cached three"])
+
+    cached, missing = DeepLDiff::Cache.new(:en, :ru, provider: "deepl")
+                                      .cached_and_missing(%w[one two three])
+
+    assert_equal ["cached one", nil, "cached three"], cached
+    assert_equal ["two"], missing
   end
 
   private

--- a/test/deepl_diff/request_test.rb
+++ b/test/deepl_diff/request_test.rb
@@ -96,28 +96,18 @@ class RequestTest < Minitest::Test
     assert_equal [[%w[One Black So Red that], :en, :ru, {}]], api.calls
   end
 
-  # The options hash belongs to the caller. Consuming :from and :to out of it
-  # broke the second call with the same hash, and blew up outright on a frozen
-  # one -- which is what a hash of settings kept in a constant is.
-  def test_leaves_the_callers_options_hash_alone
+  # Keyword arguments collect a fresh hash on every call, which is what
+  # made the 2.1.0 fix for the consumed-hash bug unnecessary here.
+  def test_a_splatted_options_hash_survives_repeated_calls
     options = { from: :en, to: :ru }
 
     DeepLDiff.api = FakeApi.new(["Какая-то строка", "Какая-то строка"])
     DeepLDiff.cache_store = FakeCacheStore.new
 
     2.times do
-      assert_equal "Какая-то строка", DeepLDiff::Request.new("Some string", options).call
+      assert_equal "Какая-то строка", DeepLDiff.translate("Some string", **options)
     end
     assert_equal({ from: :en, to: :ru }, options)
-  end
-
-  def test_accepts_a_frozen_options_hash
-    DeepLDiff.api = FakeApi.new(["Какая-то строка"])
-    DeepLDiff.cache_store = FakeCacheStore.new
-
-    result = DeepLDiff::Request.new("Some string", { from: :en, to: :ru }.freeze).call
-
-    assert_equal "Какая-то строка", result
   end
 
   # A detected language comes back as a String while :to is usually a Symbol,
@@ -128,7 +118,7 @@ class RequestTest < Minitest::Test
     DeepLDiff.api = api
     DeepLDiff.cache_store = FakeCacheStore.new
 
-    result = DeepLDiff::Request.new("привет", { to: :ru }).call
+    result = DeepLDiff::Request.new("привет", to: :ru).call
 
     assert_equal "привет", result
     assert_equal 1, api.calls.size, "only the detection call should be made"
@@ -139,7 +129,7 @@ class RequestTest < Minitest::Test
     DeepLDiff.cache_store = FakeCacheStore.new
 
     error = assert_raises(DeepLDiff::Request::Error) do
-      DeepLDiff::Request.new({ a: "One", b: "Two" }, { from: :en, to: :ru }).call
+      DeepLDiff::Request.new({ a: "One", b: "Two" }, from: :en, to: :ru).call
     end
 
     assert_match(/returned 1 translations for 2 values/, error.message)
@@ -154,7 +144,7 @@ class RequestTest < Minitest::Test
       DeepLDiff.api = api
       DeepLDiff.cache_store = FakeCacheStore.new
 
-      assert_equal value, DeepLDiff::Request.new(value, { from: :en, to: :ru }).call
+      assert_equal value, DeepLDiff::Request.new(value, from: :en, to: :ru).call
       assert_empty api.calls
     end
   end
@@ -164,7 +154,7 @@ class RequestTest < Minitest::Test
     DeepLDiff.api = api
     DeepLDiff.cache_store = FakeCacheStore.new
 
-    assert_nil DeepLDiff::Request.new(nil, { from: :en, to: :ru }).call
+    assert_nil DeepLDiff::Request.new(nil, from: :en, to: :ru).call
     assert_empty api.calls
   end
 
@@ -174,7 +164,7 @@ class RequestTest < Minitest::Test
     DeepLDiff.api = FakeApi.new(%w[Один])
     DeepLDiff.cache_store = FakeCacheStore.new
 
-    result = DeepLDiff::Request.new({ a: "One", n: 42, skip: nil }, { from: :en, to: :ru }).call
+    result = DeepLDiff::Request.new({ a: "One", n: 42, skip: nil }, from: :en, to: :ru).call
 
     assert_equal({ a: "Один", n: 42, skip: "" }, result)
   end
@@ -186,7 +176,7 @@ class RequestTest < Minitest::Test
     DeepLDiff.api = api
     DeepLDiff.cache_store = FakeCacheStore.new
 
-    DeepLDiff::Request.new({ a: "One", b: "Two" }, { from: :en, to: :ru }).call
+    DeepLDiff::Request.new({ a: "One", b: "Two" }, from: :en, to: :ru).call
 
     assert_equal 2, api.calls.size, "one call per text at a batch size of 1"
   end
@@ -200,6 +190,6 @@ class RequestTest < Minitest::Test
     DeepLDiff.api = api
     DeepLDiff.cache_store = FakeCacheStore.new
 
-    [DeepLDiff::Request.new(values, { from: :en, to: :ru }).call, api]
+    [DeepLDiff::Request.new(values, from: :en, to: :ru).call, api]
   end
 end

--- a/test/deepl_diff/request_test.rb
+++ b/test/deepl_diff/request_test.rb
@@ -9,11 +9,13 @@ class RequestTest < Minitest::Test
   # Records what it was asked to translate so the call can be asserted on,
   # and answers with a canned response.
   class FakeApi
-    attr_reader :calls
+    attr_reader :calls, :max_request_size, :max_batch_size
 
-    def initialize(response, detected: nil)
+    def initialize(response, detected: nil, max_request_size: 1_000_000, max_batch_size: 1_000_000)
       @response = response
       @detected = detected
+      @max_request_size = max_request_size
+      @max_batch_size = max_batch_size
       @calls = []
     end
 
@@ -21,7 +23,8 @@ class RequestTest < Minitest::Test
       @calls << [text, from, to, options]
       return Detection.new(@detected) if from.nil?
 
-      @response.map { |value| Translation.new(value) }
+      taken = @response.shift(Array(text).size)
+      taken.map { |value| Translation.new(value) }
     end
   end
 
@@ -99,7 +102,7 @@ class RequestTest < Minitest::Test
   def test_leaves_the_callers_options_hash_alone
     options = { from: :en, to: :ru }
 
-    DeepLDiff.api = FakeApi.new(["Какая-то строка"])
+    DeepLDiff.api = FakeApi.new(["Какая-то строка", "Какая-то строка"])
     DeepLDiff.cache_store = FakeCacheStore.new
 
     2.times do
@@ -174,6 +177,18 @@ class RequestTest < Minitest::Test
     result = DeepLDiff::Request.new({ a: "One", n: 42, skip: nil }, { from: :en, to: :ru }).call
 
     assert_equal({ a: "Один", n: 42, skip: "" }, result)
+  end
+
+  # Proves the generalisation took effect rather than merely being
+  # described: an adapter declaring tiny limits must change the batching.
+  def test_batches_according_to_the_limits_the_adapter_declares
+    api = FakeApi.new(%w[Один Два], max_batch_size: 1)
+    DeepLDiff.api = api
+    DeepLDiff.cache_store = FakeCacheStore.new
+
+    DeepLDiff::Request.new({ a: "One", b: "Two" }, { from: :en, to: :ru }).call
+
+    assert_equal 2, api.calls.size, "one call per text at a batch size of 1"
   end
 
   private

--- a/test/deepl_diff/request_test.rb
+++ b/test/deepl_diff/request_test.rb
@@ -96,9 +96,11 @@ class RequestTest < Minitest::Test
     assert_equal [[%w[One Black So Red that], :en, :ru, {}]], api.calls
   end
 
-  # Keyword arguments collect a fresh hash on every call, which is what
-  # made the 2.1.0 fix for the consumed-hash bug unnecessary here.
-  def test_a_splatted_options_hash_survives_repeated_calls
+  # True of the public interface, but not new: 2.1.0 already protected the
+  # caller's hash from mutation by dup-ing it in the initializer. Keyword
+  # arguments keep that guarantee for a different reason (a fresh hash per
+  # call), but this test alone cannot tell the two implementations apart.
+  def test_repeated_calls_leave_the_callers_options_hash_alone
     options = { from: :en, to: :ru }
 
     DeepLDiff.api = FakeApi.new(["Какая-то строка", "Какая-то строка"])
@@ -108,6 +110,15 @@ class RequestTest < Minitest::Test
       assert_equal "Какая-то строка", DeepLDiff.translate("Some string", **options)
     end
     assert_equal({ from: :en, to: :ru }, options)
+  end
+
+  # This is what actually changed: the initializer declares one positional
+  # parameter now, so a single positional options hash -- which is what every
+  # pre-task caller passed -- is no longer accepted.
+  def test_the_positional_options_hash_is_no_longer_accepted
+    assert_raises(ArgumentError) do
+      DeepLDiff::Request.new("text", { from: :en, to: :ru })
+    end
   end
 
   # A detected language comes back as a String while :to is usually a Symbol,

--- a/test/deepl_diff/request_test.rb
+++ b/test/deepl_diff/request_test.rb
@@ -3,11 +3,8 @@
 require "test_helper"
 
 class RequestTest < Minitest::Test
-  Translation = Struct.new(:text)
-  Detection = Struct.new(:detected_source_language)
-
-  # Records what it was asked to translate so the call can be asserted on,
-  # and answers with a canned response.
+  # A minimal adapter. Records what it was asked to translate so the call
+  # can be asserted on, and answers with a canned response.
   class FakeApi
     attr_reader :calls, :max_request_size, :max_batch_size
 
@@ -19,13 +16,17 @@ class RequestTest < Minitest::Test
       @calls = []
     end
 
-    def translate(text, from, to, options = {})
-      @calls << [text, from, to, options]
-      return Detection.new(@detected) if from.nil?
-
-      taken = @response.shift(Array(text).size)
-      taken.map { |value| Translation.new(value) }
+    def translate(texts, from:, to:, **options)
+      @calls << [texts, from, to, options]
+      @response.shift(texts.size)
     end
+
+    def detect(text)
+      @calls << [:detect, text]
+      @detected
+    end
+
+    def cache_key = "fake"
   end
 
   # Always misses, so every value reaches the API.
@@ -132,7 +133,18 @@ class RequestTest < Minitest::Test
     result = DeepLDiff::Request.new("привет", to: :ru).call
 
     assert_equal "привет", result
-    assert_equal 1, api.calls.size, "only the detection call should be made"
+    assert_equal [[:detect, "привет"]], api.calls
+  end
+
+  def test_raises_when_from_is_missing_and_the_adapter_cannot_detect
+    DeepLDiff.api = DeepLDiff::Adapters::Null.new
+    DeepLDiff.cache_store = FakeCacheStore.new
+
+    error = assert_raises(DeepLDiff::Request::Error) do
+      DeepLDiff::Request.new("text", to: :ru).call
+    end
+
+    assert_match(/cannot detect/, error.message)
   end
 
   def test_raises_when_the_api_returns_fewer_translations_than_asked_for

--- a/test/support/adapter_contract.rb
+++ b/test/support/adapter_contract.rb
@@ -11,9 +11,12 @@ module AdapterContract
   end
 
   def test_translate_preserves_order
-    result = adapter.translate(%w[first second], from: :en, to: :ru)
+    texts = %w[first second third]
+    individually = texts.map { |text| adapter.translate([text], from: :en, to: :ru).first }
+    batched = adapter.translate(texts, from: :en, to: :ru)
 
-    refute_equal result[0], result[1]
+    assert_equal 3, batched.size
+    assert_equal individually, batched
   end
 
   def test_translate_accepts_provider_options

--- a/test/support/adapter_contract.rb
+++ b/test/support/adapter_contract.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# The executable form of the adapter contract. Every adapter includes this
+# and defines #adapter; anything that passes can be TranslationDiff.api.
+module AdapterContract
+  def test_translate_returns_one_string_per_input
+    result = adapter.translate(%w[one two three], from: :en, to: :ru)
+
+    assert_equal 3, result.size
+    result.each { |value| assert_kind_of String, value }
+  end
+
+  def test_translate_preserves_order
+    result = adapter.translate(%w[first second], from: :en, to: :ru)
+
+    refute_equal result[0], result[1]
+  end
+
+  def test_translate_accepts_provider_options
+    result = adapter.translate(%w[one], from: :en, to: :ru, formality: :less)
+
+    assert_equal 1, result.size
+  end
+
+  def test_max_request_size_is_a_positive_integer
+    assert_kind_of Integer, adapter.max_request_size
+    assert_operator adapter.max_request_size, :>, 0
+  end
+
+  def test_max_batch_size_is_a_positive_integer
+    assert_kind_of Integer, adapter.max_batch_size
+    assert_operator adapter.max_batch_size, :>, 0
+  end
+
+  def test_cache_key_is_a_non_empty_string
+    assert_kind_of String, adapter.cache_key
+    refute_empty adapter.cache_key
+  end
+end


### PR DESCRIPTION
Six tasks of the generalisation work. The rename to `translation_diff` follows in a separate PR.

The gem has contained no reference to DeepL since 2.0.0 — the API object is supplied by the application and duck typed on one method. But the duck type was never written down (it was whatever `deepl-rb` happened to expose), and DeepL's request limits were hard-coded into the chunker. This PR fixes both, and one correctness bug that generalising exposed.

## The adapter contract

`AdapterContract` is the interface as an executable test module. Any adapter is validated by including it and defining `adapter`. Two adapters ship: `Adapters::DeepL` (current behaviour) and `Adapters::Null` (tests).

`deepl-rb` does **not** become a dependency. The adapter takes its client as an argument and `::DeepL` resolves at call time — the same technique that already keeps `redis-namespace` and `ratelimit` out of the gemspec. Runtime dependencies remain `ox` and `punkt-segmenter`.

## Detection is its own method, and optional

Before this, `api.translate(sample, nil, to)` returned an object of a **different type** than the same method with a non-nil `from` — one method, two return types, told apart by an argument's value. Now `detect(text)` is separate, and an adapter that does not implement it makes `from:` required with a clear message instead of dying with `NoMethodError`.

## Limits belong to the provider

`MAX_CHUNK_SIZE = 1700` and `COUNT_LIMIT = 300` were DeepL's numbers living in the core. They are now declared by the adapter and required by `Chunker`. With one provider a default looks meaningful; with two it silently lies about the second — and this file already shipped a bug of exactly that shape in 2.1.0.

## Options are keyword arguments

`translate(values, from:, to:, **options)`. This deletes the `options.dup` added in 2.1.0 along with the class of bug it worked around: keyword arguments collect a fresh hash per call, so the caller's hash can no longer be consumed.

## Cache keys, and a bug generalising exposed

The key gains the provider, a digest of the provider options, and normalised language codes:

```
before  en:ru:<md5>
after   deepl:en:ru:<digest>:<md5>
```

Without this, switching providers against the same Redis silently returns the first provider's translations, and `formality: :less` shares a key with the default. `from: "EN"` and `from: :en` also stopped producing two entries for identical work.

The options digest is built on a canonical encoding, **not `#inspect`**. Ruby 3.4 changed how symbol-keyed hashes render, so an `#inspect`-based digest gives different keys on different supported Rubies — upgrading Ruby would have silently re-paid for every translation. Verified that 3.2.4 and 4.0.5 now produce byte-identical keys. Any option value that cannot be encoded stably raises rather than producing an unstable key.

> [!IMPORTANT]
> Every cache key changes. Nothing cached by earlier versions is reused.

## Test plan

- `bundle exec rake test` — 74 runs, 126 assertions, 0 failures (was 46 before this work).
- `bundle exec rubocop` — no offences, with no cop disabled anywhere to achieve it.
- Every task was reviewed independently; three needed a fix round. Two reviews caught tests that passed for the wrong reason and were replaced with ones that fail on the old code.