### PR TITLE
fix: address the final pre-release review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [3.0.0] - 2026-09-07
+
+First release under the name **translation_diff**. This gem was published as
+`deepl_diff` through 2.2.0.
+
+### Breaking
+
+- Renamed the gem to `translation_diff` and the module to `TranslationDiff`.
+- `TranslationDiff.api` must now be an adapter satisfying the five-method
+  contract (`translate`, optional `detect`, `max_request_size`,
+  `max_batch_size`, `cache_key`) instead of a raw client such as `DeepL`.
+- `translate` takes keyword arguments -- `translate(values, from:, to:, **options)`
+  -- and no longer accepts a positional options hash.
+- Request-size and batch-size limits moved out of `Chunker` and into the
+  adapter (`#max_request_size`, `#max_batch_size`); they are no longer
+  hard-coded to DeepL's numbers.
+- **Every cache key changes.** The key now includes the provider's
+  `cache_key`, a digest of the provider options, and lowercased language
+  codes. Nothing cached by `deepl_diff` -- or by an earlier `translation_diff`
+  prerelease -- is reused. The next translation of every sentence is a cache
+  miss, once, everywhere.
+
+### Added
+
+- `TranslationDiff::Adapters::DeepL` and `TranslationDiff::Adapters::Null`.
+- `test/support/adapter_contract.rb`, the executable form of the adapter
+  contract; any third-party adapter can include it to verify it behaves as
+  documented.
+- `detect` is now its own adapter method. Previously
+  `api.translate(sample, nil, to)` returned an object of a different shape
+  than the same call with `from:` given -- one method, two return types,
+  told apart by an argument's value. An adapter with no `detect` makes
+  `from:` required and raises a clear error when it is missing, instead of
+  `NoMethodError`.
+
+### Changed
+
+- The cache key's options digest uses a canonical, version-stable encoding
+  instead of `Hash#inspect`, which renders symbol-keyed hashes differently
+  across Ruby 3.2-4.0.
+
+## [2.2.0] - 2026-09-07
+
+Message-only release under the `deepl_diff` name. No code changes.
+
+### Added
+
+- `spec.post_install_message`, pointing installers at `translation_diff`,
+  the gem's new name. `deepl_diff` 2.2.0 is the last release under that
+  name and keeps working for anyone pinned to it.
+
+## [2.1.0] - 2026-09-07
+
+Six bugs found while auditing the library, each reproduced against the real
+behaviour and covered by a regression test.
+
+### Added
+
+- `DeepLDiff::Request::Error`, raised when the adapter returns fewer
+  translations than requested, instead of letting `nil` reach `Spacing` and
+  fail two layers away as `NoMethodError`.
+
+### Fixed
+
+- The options hash passed to `Request` was consumed with `Hash#delete`, so a
+  second call with the same hash -- or any frozen hash -- broke.
+- The chunker compared raw `String#size` against a limit meant for the
+  escaped request, so Cyrillic and other non-Latin text could run several
+  times over the actual request-size limit.
+- A detected source language (a `String`) was compared against `:to`
+  (usually a `Symbol`) with `==`, so the same-language short circuit never
+  fired and text was translated into its own language.
+- Non-string scalars (`nil`, `Integer`, `Symbol`) raised instead of passing
+  through untouched.
+- The chunk count limit was off by one.
+
+### Upgrade note
+
+The chunker fix changes how non-Latin text is split into requests: chunks
+are smaller, so there are more requests for the same number of characters
+billed. A `MAX_CHUNK_SIZE` tuned empirically against Cyrillic now produces a
+very different payload than it did.
+
+## [2.0.0] - 2026-09-07
+
+### Breaking
+
+- Six unused or duck-typed runtime dependencies were dropped:
+  `dry-initializer`, `connection_pool`, `redis`, `deepl-rb`,
+  `redis-namespace`, `ratelimit`. Applications that relied on this gem to
+  install them must now depend on them directly.
+- `RedisRateLimiter` takes `threshold:` and `interval:` as keyword
+  arguments.
+
+### Fixed
+
+- `RedisRateLimiter` declared `threshold` and `interval` as positional
+  parameters, so the keyword call the README already documented silently
+  discarded them and fell back to the defaults (8000 / 60).
+
+## [1.1.1] - 2026-09-07
+
+No changes to `lib/`.
+
+### Changed
+
+- The test suite moved from RSpec to Minitest.
+- The gem is published from CI through RubyGems trusted publishing instead
+  of a personal API key.
+
+## [1.1.0] - 2026-09-07
+
+### Changed
+
+- Every runtime dependency is now explicitly versioned; the gem requires
+  Ruby >= 3.2.
+- CI moved from Travis to GitHub Actions, running against Ruby 3.2, 3.3,
+  3.4 and 4.0, plus a RuboCop job.
+
+### Fixed
+
+- `cgi/escape`, `digest/md5`, `forwardable` and `stringio` are now required
+  explicitly instead of relying on them being pulled in transitively.
+- DeepL options were passed via `**options` into a method that takes a
+  positional hash, so an empty options hash passed nothing.
+- `Chunker::Chunk` members `values`/`size` were renamed (eventually to
+  `texts`/`escaped_size`) because they shadowed `Struct#values` and
+  `Struct#size`.
+
+[3.0.0]: https://github.com/Halvanhelv/translation_diff/compare/v2.2.0...v3.0.0
+[2.2.0]: https://github.com/Halvanhelv/deepl_diff/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/Halvanhelv/deepl_diff/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/Halvanhelv/deepl_diff/compare/v1.1.1...v2.0.0
+[1.1.1]: https://github.com/Halvanhelv/deepl_diff/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/Halvanhelv/deepl_diff/compare/v1.0.1...v1.1.0

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2026 Islam Gagiev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ This gem loads two: [`ox`](https://github.com/ohler55/ox) to walk the HTML, and
 [`punkt-segmenter`](https://github.com/lfcipriani/punkt-segmenter) to split text
 into sentences.
 
-Everything else is duck typed and supplied by you: `TranslationDiff.api` is anything
-answering to `#translate`, and both `RedisCacheStore` and `RedisRateLimiter`
-take anything answering to `#with`. Bring your own client, pool and store.
+Everything else is duck typed and supplied by you: `TranslationDiff.api` must satisfy
+the five-method adapter contract described in [Adapters and the adapter
+contract](#adapters-and-the-adapter-contract) below -- not just `#translate` -- and both
+`RedisCacheStore` and `RedisRateLimiter` take anything answering to `#with`. Bring your
+own client, pool and store.
 
 ## Installation
 
@@ -99,8 +101,13 @@ def translate(texts, from:, to:, **options)
 # guessing.
 def detect(text)
 
-# The largest single request the provider accepts, in characters. Used to
-# split long texts into multiple requests.
+# The largest single request the provider accepts, in characters of the
+# escaped form -- which is what the chunker measures (CGI.escape(text).size,
+# not String#size). For Cyrillic and other non-Latin text this is 6 to 9
+# times the raw character count. Declaring the provider's raw character
+# limit here will either waste most of the budget (if you under-report) or
+# raise Chunker::Error on text the provider would actually have accepted
+# (if you over-report). Used to split long texts into multiple requests.
 def max_request_size
 
 # The largest number of strings the provider accepts in one batched request.
@@ -122,6 +129,30 @@ behave as documented above.
 `deepl_diff` is deprecated in favor of `translation_diff`, which is
 functionally the same gem under a name that no longer implies a dependency on
 DeepL specifically.
+
+**Upgrading from `deepl_diff`:** every cache key changed in 3.0.0 -- the provider,
+the provider options and normalised language codes are now part of the key.
+Nothing cached by `deepl_diff` is reused; the next translation of every sentence is
+a cache miss, once, everywhere. See [CHANGELOG.md](CHANGELOG.md) for the full list
+of breaking changes.
+
+## Errors
+
+Every error this gem raises inherits from `TranslationDiff::Error < StandardError`,
+so rescuing the gem's failures in one clause is a single `rescue TranslationDiff::Error`:
+
+```
+TranslationDiff::Error
+├── TranslationDiff::Request::Error        # e.g. api/cache_store not configured,
+│                                           # adapter returned the wrong number of
+│                                           # translations, from: missing and the
+│                                           # adapter cannot detect
+├── TranslationDiff::Cache::Error          # provider options have no stable
+│                                           # serialisation for the cache key
+├── TranslationDiff::Chunker::Error        # a single value is larger than the
+│                                           # adapter's max_request_size
+└── TranslationDiff::RedisRateLimiter::RateLimitExceeded
+```
 
 ## How it works
 

--- a/lib/translation_diff.rb
+++ b/lib/translation_diff.rb
@@ -9,6 +9,7 @@ require "ox"
 require "punkt-segmenter"
 
 require "translation_diff/version"
+require "translation_diff/error"
 
 require "translation_diff/adapters"
 require "translation_diff/adapters/null"

--- a/lib/translation_diff/adapters/deepl.rb
+++ b/lib/translation_diff/adapters/deepl.rb
@@ -28,8 +28,4 @@ class TranslationDiff::Adapters::DeepL
   def max_request_size = MAX_REQUEST_SIZE
   def max_batch_size = MAX_BATCH_SIZE
   def cache_key = "deepl"
-
-  private
-
-  attr_reader :client
 end

--- a/lib/translation_diff/cache.rb
+++ b/lib/translation_diff/cache.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TranslationDiff::Cache
-  class Error < StandardError; end
+  class Error < TranslationDiff::Error; end
 
   # An application uses a handful of distinct option sets, so 32 bits of
   # digest is ample to keep them apart; the full 128-bit MD5 would just

--- a/lib/translation_diff/chunker.rb
+++ b/lib/translation_diff/chunker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TranslationDiff::Chunker
-  class Error < StandardError; end
+  class Error < TranslationDiff::Error; end
 
   Chunk = Struct.new(:texts, :escaped_size)
 

--- a/lib/translation_diff/error.rb
+++ b/lib/translation_diff/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Common ancestor for every error this gem raises. Without it, a caller who
+# wants to rescue anything TranslationDiff can throw has to list four
+# unrelated classes; with it, `rescue TranslationDiff::Error` is enough.
+class TranslationDiff::Error < StandardError; end

--- a/lib/translation_diff/redis_rate_limiter.rb
+++ b/lib/translation_diff/redis_rate_limiter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TranslationDiff::RedisRateLimiter
-  class RateLimitExceeded < StandardError; end
+  class RateLimitExceeded < TranslationDiff::Error; end
 
   DEFAULT_THRESHOLD = 8000
   DEFAULT_INTERVAL = 60

--- a/lib/translation_diff/request.rb
+++ b/lib/translation_diff/request.rb
@@ -3,7 +3,7 @@
 class TranslationDiff::Request
   extend Forwardable
 
-  class Error < StandardError; end
+  class Error < TranslationDiff::Error; end
 
   def_delegators :TranslationDiff, :api, :cache_store, :rate_limiter
   def_delegators :"TranslationDiff::Linearizer", :linearize, :restore
@@ -51,10 +51,10 @@ class TranslationDiff::Request
   end
 
   def validate_globals
-    raise "Set TranslationDiff.api before calling ::translate" unless api
+    raise Error, "Set TranslationDiff.api before calling ::translate" unless api
     return if cache_store
 
-    raise "Set TranslationDiff.cache_store before calling ::translate"
+    raise Error, "Set TranslationDiff.cache_store before calling ::translate"
   end
 
   # Extracts flat text array

--- a/test/translation_diff/cache_test.rb
+++ b/test/translation_diff/cache_test.rb
@@ -92,6 +92,15 @@ class CacheTest < Minitest::Test
     refute_equal @store.keys[0], @store.keys[1]
   end
 
+  # An Array-valued option (e.g. glossary_ids: %w[a b]) exercises the Array
+  # branch of #canonical, which no other test in this file reaches.
+  def test_an_array_option_value_is_part_of_the_digest
+    key_for(options: { glossary_ids: %w[a b] })
+    key_for(options: { glossary_ids: %w[a c] })
+
+    refute_equal @store.keys[0], @store.keys[1]
+  end
+
   # An option value with no stable serialisation (no #inspect of its own,
   # or one that embeds a memory address) must not be allowed to silently
   # produce an unreproducible cache key.

--- a/test/translation_diff/request_test.rb
+++ b/test/translation_diff/request_test.rb
@@ -46,6 +46,24 @@ class RequestTest < Minitest::Test
     end
   end
 
+  # Already has every key cached, regardless of what it is asked for. Proves
+  # the all-cached short circuit in Request#chunks_translated: the gem's
+  # headline behaviour is serving a translation from cache without calling
+  # the adapter at all.
+  class AllCachedStore
+    def initialize(responses)
+      @responses = responses
+    end
+
+    def read_multi(keys)
+      @responses.first(keys.size)
+    end
+
+    def write(*)
+      raise "should not write when nothing was missing"
+    end
+  end
+
   def teardown
     TranslationDiff.api = nil
     TranslationDiff.cache_store = nil
@@ -202,6 +220,20 @@ class RequestTest < Minitest::Test
     TranslationDiff::Request.new({ a: "One", b: "Two" }, from: :en, to: :ru).call
 
     assert_equal 2, api.calls.size, "one call per text at a batch size of 1"
+  end
+
+  # Every fake cache store elsewhere in this file always misses, so this is
+  # the only Request-level test exercising a cache hit: a translation served
+  # from the store without ever reaching the adapter.
+  def test_serves_a_translation_from_cache_without_calling_the_adapter
+    api = FakeApi.new([])
+    TranslationDiff.api = api
+    TranslationDiff.cache_store = AllCachedStore.new(["Какая-то строка"])
+
+    result = TranslationDiff::Request.new("Some string", from: :en, to: :ru).call
+
+    assert_equal "Какая-то строка", result
+    assert_empty api.calls
   end
 
   private

--- a/translation_diff.gemspec
+++ b/translation_diff.gemspec
@@ -11,16 +11,16 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Islam Gagiev"]
   spec.email         = ["omniacinis@gmail.com"]
 
-  spec.summary       = %(
-DeepL API wrapper for Ruby which helps to translate only changes
-between revisions of long texts.
-
-  )
+  spec.summary = "A translation cache that sends only new or changed sentences to your provider."
   spec.description = %(
-DeepL API wrapper for Ruby which helps to translate only changes
-between revisions of long texts.
+TranslationDiff extracts translatable text from HTML, splits it into
+sentences, and caches each sentence by content hash. Only the sentences
+missing from the cache are sent to whichever translation provider you plug
+in through a small adapter contract, so re-translating a long text after a
+small edit costs the price of the edit, not the whole text.
   )
   spec.homepage = "https://github.com/Halvanhelv/translation_diff"
+  spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2"
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
The whole-branch review before publishing 3.0.0 returned "do not ship" with one Critical and five Important findings. The release was cancelled mid-flight, before the push step ran, so 3.0.0 was never burned. This fixes all eight findings.

Nothing here is a code defect. Everything blocking was documentation or metadata — which is exactly the class of thing that becomes permanent the moment a gem is published.

## The Critical one

`spec.summary` and `spec.description` still read *"DeepL API wrapper for Ruby"*. That is the text on rubygems.org and in `gem search`, forever, for a gem whose entire premise is no longer being tied to DeepL. The rename audit grepped the gem and module **names**, so this phrasing slipped through every per-task review.

```ruby
spec.summary = "A translation cache that sends only new or changed sentences to your provider."
```

## The rest

- **README contradicted itself.** The Dependencies section still said `api` is "anything answering to `#translate`", stale from 2.x, sixty lines above the five-method contract. A reader going top-down would assign a bare client and get `NoMethodError`.
- **`max_request_size` units were wrong.** Documented as "in characters"; `Chunker#escaped_size` measures `CGI.escape(text).size`, 6-9x larger for Cyrillic. A third-party adapter author declaring their provider's real limit would either waste most of the budget or hit `Chunker::Error` on text the provider would have accepted.
- **No CHANGELOG, and no warning that every cache key changes.** The design names total cache invalidation as its one unmitigated risk, and names exactly one mitigation: saying so in the CHANGELOG and README. Both now exist.
- **No license.** `spec.license = "MIT"` and `LICENSE.txt`.
- **Four error classes, no common ancestor.** `TranslationDiff::Error` is now the ancestor of `Request::Error`, `Cache::Error`, `Chunker::Error` and `RedisRateLimiter::RateLimitExceeded`, so the gem can be rescued in one clause. Every existing class name is unchanged. `validate_globals` no longer raises bare `RuntimeError` strings.
- **Two untested branches.** The all-cached short circuit in `Request` — the gem's headline behaviour — was covered by no test, because every Request-level fake store always missed. The new test's store raises if `write` is called and asserts `assert_empty api.calls`, so it proves the adapter is skipped rather than only that the result is right.

## Test plan

- `bundle exec rake test` — 76 runs, 130 assertions, 0 failures (was 74/126).
- `bundle exec rubocop` — no offences, no cop disabled.
- Coverage 98.22% → 98.81%.
- Re-reviewed against all eight findings: every one addressed, no new breakage.

> [!NOTE]
> Merging this does **not** publish anything. 3.0.0 stays unreleased while the sentence segmenter replaces `punkt-segmenter`, so the cache is invalidated once rather than twice.