### PR TITLE
chore: bump the version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.0] - 2026-09-07
+## [3.1.0] - 2026-09-08
 
 First release under the name **translation_diff**. This gem was published as
 `deepl_diff` through 2.2.0.
+
+There is no 3.0.0 entry. That version was tagged during the rename and then
+held back before it reached RubyGems, so no `translation_diff` gem was ever
+published as 3.0.0 and the tag names a commit that predates most of what is
+described below. Everything here is relative to `deepl_diff` 2.2.0.
 
 ### Breaking
 
@@ -59,7 +64,7 @@ First release under the name **translation_diff**. This gem was published as
   checked a subject nothing ever incremented. The limiter never limited
   anything, in every release back to `v1.0.2` (tagged 2023-02-16, roughly
   three years ago). If you have `rate_limit` configured, your traffic has
-  never actually been throttled; on upgrading to 3.0.0 it will be, for the
+  never actually been throttled; on upgrading to 3.1.0 it will be, for the
   first time, against a threshold you set once and have never seen fire. You
   changed no configuration, but your throttling behaviour changes on
   upgrade. Re-validate `rate_limit` and `rate_interval` before upgrading --
@@ -275,7 +280,7 @@ No changes to `lib/`.
   `texts`/`escaped_size`) because they shadowed `Struct#values` and
   `Struct#size`.
 
-[3.0.0]: https://github.com/Halvanhelv/translation_diff/compare/v2.2.0...v3.0.0
+[3.1.0]: https://github.com/Halvanhelv/translation_diff/compare/v2.2.0...v3.1.0
 [2.2.0]: https://github.com/Halvanhelv/deepl_diff/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Halvanhelv/deepl_diff/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Halvanhelv/deepl_diff/compare/v1.1.1...v2.0.0

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ exceeded within its interval. Neither `redis` nor `connection_pool` nor
 check, so an application that configures no `rate_limit` never needs it, and
 its absence raises `TranslationDiff::Error` naming the gem to add.
 
-**Upgrading to 3.0.0: re-validate your `rate_limit` threshold.** Before this
+**Upgrading to 3.1.0: re-validate your `rate_limit` threshold.** Before this
 release, `RedisRateLimiter` never actually limited anything -- a signature
 mismatch with the `ratelimit` gem meant it recorded hits under a subject
 `exceeded?` never read, so the threshold could never be reached. That bug
@@ -646,21 +646,20 @@ requests at 1700 characters and batches at 300 sentences.
 
 ## Former name and upgrading
 
-This gem was published as `deepl_diff` before version 3.0.0. `deepl_diff` is
+This gem was published as `deepl_diff` through 2.2.0. `deepl_diff` is
 deprecated in favor of `translation_diff`, which is functionally the same
 gem under a name that no longer implies a dependency on DeepL specifically.
 
-**Upgrading from `deepl_diff` or from a `translation_diff` release before
-3.0.0:** every cache key changed in 3.0.0 -- the provider, the provider
-options and normalised language codes are now part of the key. Nothing
-cached previously is reused; the next translation of every sentence is a
-cache miss, once, everywhere. `TranslationDiff.api`, `.cache_store`,
+**Upgrading from `deepl_diff`:** every cache key changed in 3.1.0 -- the
+provider, the provider options and normalised language codes are now part of
+the key. Nothing cached previously is reused; the next translation of every
+sentence is a cache miss, once, everywhere. `TranslationDiff.api`, `.cache_store`,
 `.segmenter` and `.rate_limiter` -- the four module-level accessors earlier
 versions configured directly -- are gone; configure `TranslationDiff.config`
 (or use `TranslationDiff.configure`) instead. If you have `rate_limit`
 configured, also read the upgrading note in
 [The rate limiter contract](#the-rate-limiter-contract): the limiter was
-never actually enforcing your threshold before 3.0.0, and it starts doing so
+never actually enforcing your threshold before 3.1.0, and it starts doing so
 now. See [CHANGELOG.md](CHANGELOG.md) for the full list of breaking changes.
 
 ## Development

--- a/lib/translation_diff/version.rb
+++ b/lib/translation_diff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TranslationDiff
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Bumps `TranslationDiff::VERSION` to 3.1.0 and renames the changelog's unreleased section to match. No code changes.

`3.0.0` is skipped rather than used. That version was tagged during the rename and then held back before it reached RubyGems, so no `translation_diff` gem was ever published under it, and the tag names a commit that predates the segmenter seam (#11) and the configuration rewrite (#12). Reusing the number would mean a published gem whose contents disagree with an existing public tag.

The changelog now says so explicitly, so a reader who notices the jump from `deepl_diff` 2.2.0 straight to 3.1.0 finds the reason rather than guessing.

Version references in the README's upgrading section were updated with it, and the "upgrading from a `translation_diff` release before 3.0.0" phrasing dropped — there are no earlier `translation_diff` releases to upgrade from.
