### PR TITLE
fix: markup the tokenizer was dropping, and the Google provider's format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,10 @@ described below. Everything here is relative to `deepl_diff` 2.2.0.
   `google_api_key` and `google_project_id`; an API key alone is enough, and
   with none configured the gem reads `TRANSLATE_KEY`/`GOOGLE_CLOUD_KEY` or
   falls back to application default credentials. The provider asks for
-  `format: :text` -- Google's own default HTML-escapes its output -- and
-  downcases bare language codes so a configuration written for DeepL
-  (`"EN"`) keeps working, leaving subtagged codes such as `"zh-Hans"` alone.
+  `format: :html`, which the tokenizer's output requires -- a `notranslate`
+  span is handed over with its tags -- and downcases bare language codes so
+  a configuration written for DeepL (`"EN"`) keeps working, leaving
+  subtagged codes such as `"zh-Hans"` alone.
 - `TranslationDiff::Configuration`, a declarative settings object built
   through the `option(key, default)` macro. Options fall back to their
   default until assigned, treat a blank string as unset, and support a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,14 @@ described below. Everything here is relative to `deepl_diff` 2.2.0.
 
 ### Fixed
 
+- Comments, doctypes and CDATA sections survive a translation. `Tokenizer`
+  declared no handler for those three Ox SAX events, so the bytes each one
+  covered belonged to no token: a leading `<!-- ... -->` or `<!DOCTYPE html>`
+  disappeared from the result outright, and a comment in the middle of a
+  sentence leaked its `<!` into the surrounding text and handed the comment's
+  own contents to the translation provider as prose -- both paying for the
+  characters and risking an internal note coming back translated in place of
+  the comment.
 - `TranslationDiff::RedisRateLimiter` requires `ratelimit` lazily, on the
   first check, and raises `TranslationDiff::Error` naming the gem to add
   when it is missing. Previously the bare constant surfaced a raw

--- a/README.md
+++ b/README.md
@@ -181,11 +181,24 @@ default credentials, which is the path where `google_project_id` matters.
 Two things this provider does on your behalf, both of which would otherwise
 be silent problems:
 
-- **It asks for plain text.** Google's own default is `format: html`, which
-  HTML-escapes its own output -- an apostrophe returns as `&#39;`. By the
-  time anything reaches a provider the Tokenizer has already separated
-  markup from text and is sending only text, so plain is what it must ask
-  for. Pass `format: :html` per call to override that.
+- **It asks for HTML**, which is Google's own default and what this gem has
+  always sent. What reaches a provider is not plain text: a `notranslate`
+  span arrives whole, tags included -- that is how the tokenizer marks
+  content the provider must leave alone -- and entities such as `&amp;`
+  stay in the text it emits. Asking for `text` makes Google translate the
+  protected span and drop its markup:
+
+  ```
+  "<span class='notranslate'>Bold Mountain</span> is a good place."
+  format: text  ->  "Болд Маунтин — хорошее место."
+  format: html  ->  "<span class='notranslate'>Bold Mountain</span> — хорошее место."
+  ```
+
+  The cost is that Google escapes its own output: a literal apostrophe
+  returns as `&#39;`. Inside the HTML fragment these values usually are,
+  that renders as an apostrophe and is correct. Inside a value that never
+  had any markup in it, it is noise -- pass `format: :text` per call when
+  translating bare strings.
 - **It downcases bare language codes.** Google's codes are lowercase, and a
   configuration written against DeepL says `"EN"`. Codes carrying a subtag
   -- `"zh-Hans"`, `"zh-CN"`, `"pt-BR"` -- are passed through untouched,

--- a/lib/translation_diff/providers/google.rb
+++ b/lib/translation_diff/providers/google.rb
@@ -21,13 +21,24 @@ class TranslationDiff::Providers::Google
   MAX_REQUEST_SIZE = 5_000
   MAX_BATCH_SIZE = 128
 
-  # Google defaults to `html`, which HTML-escapes its own output: an
-  # apostrophe comes back as "&#39;" and an ampersand as "&amp;". Everything
-  # reaching a provider has already been through the Tokenizer, which
-  # separates markup from text and sends only the text -- so plain is what
-  # this is, and plain is what it must be asked for. A caller who really is
-  # sending markup can pass `format: :html` per call.
-  DEFAULT_FORMAT = :text
+  # What arrives here is not plain text, despite having been through the
+  # Tokenizer. A notranslate span is handed over whole, tags included --
+  # that is how the tokenizer marks content the provider must leave alone --
+  # and HTML entities such as `&amp;` stay in the text it emits. Asking
+  # Google for `text` makes it translate the protected span and drop the
+  # markup around it entirely:
+  #
+  #   "<span class='notranslate'>Bold Mountain</span> is a good place."
+  #   format: text  -> "Болд Маунтин — хорошее место."
+  #   format: html  -> "<span class='notranslate'>Bold Mountain</span> — хорошее место."
+  #
+  # So `html` it is, which is also what this gem sent for its whole life
+  # before the provider seam existed. The cost is that Google escapes its
+  # own output -- a literal apostrophe returns as "&#39;" -- which is
+  # correct inside the HTML fragment these values usually are, and noise
+  # inside a value that never had markup in it. A caller translating bare
+  # strings can pass `format: :text` per call.
+  DEFAULT_FORMAT = :html
 
   # A bare alphabetic code is downcased, so a configuration written for
   # DeepL ("EN") keeps working against Google, whose codes are lowercase.

--- a/lib/translation_diff/tokenizer.rb
+++ b/lib/translation_diff/tokenizer.rb
@@ -30,6 +30,19 @@ class TranslationDiff::Tokenizer < Ox::Sax
     start_markup(name)
   end
 
+  # Ox reports a comment, a doctype and a CDATA section as events of their
+  # own, each with its own byte position, and each needs a handler here.
+  # Without one the bytes it covers belong to no token: a leading comment
+  # disappears from the rebuilt string outright, and one in the middle of a
+  # sentence leaks its "<!" into the surrounding text token and hands the
+  # comment's own contents to the translation provider as prose.
+  #
+  # None of the three has a closing event, so none may be pushed onto
+  # @context the way #start_markup pushes an element.
+  def comment(_value) = mark_markup
+  def doctype(_value) = mark_markup
+  def cdata(_value) = mark_markup
+
   def end_element(name)
     end_markup(name)
   end
@@ -118,6 +131,14 @@ class TranslationDiff::Tokenizer < Ox::Sax
 
   def fix_utf(value)
     value.encode("UTF-8", undef: :replace, invalid: :replace, replace: " ")
+  end
+
+  # A node that opens and closes in one event. Inside a notranslate region
+  # it becomes :text for the same reason element markup does there: the
+  # whole region is handed to the provider as one unit.
+  def mark_markup
+    @sequence << (notranslate? ? :text : :markup)
+    @indicies << (@pos - 1)
   end
 
   def start_markup(name)

--- a/test/translation_diff/providers/google_test.rb
+++ b/test/translation_diff/providers/google_test.rb
@@ -57,24 +57,26 @@ class GoogleProviderTest < Minitest::Test
     assert_equal %w[one-translated], provider.translate(%w[one], from: :en, to: :ru)
   end
 
-  # Google's own default is `html`, which HTML-escapes the response: an
-  # apostrophe comes back as "&#39;". By the time a value reaches a provider
-  # the Tokenizer has already stripped the markup, so what is being sent is
-  # plain text and must be asked for as plain text.
-  def test_translate_asks_for_plain_text
+  # What reaches a provider is not plain text: Tokenizer hands over a
+  # notranslate span with its tags intact, and leaves entities such as
+  # `&amp;` in the text it emits. Asking for plain text makes Google
+  # translate the protected span and drop its markup -- verified against
+  # the live API. `html` is what this gem's tokenizer contract requires,
+  # and what it has always sent.
+  def test_translate_asks_for_html
     api = FakeApi.new
 
     TranslationDiff::Providers::Google.new(api).translate(%w[one], from: :en, to: :ru)
 
-    assert_equal :text, api.calls.first.last[:format]
+    assert_equal :html, api.calls.first.last[:format]
   end
 
   def test_translate_lets_the_caller_override_the_format
     api = FakeApi.new
 
-    TranslationDiff::Providers::Google.new(api).translate(%w[one"], from: :en, to: :ru, format: :html)
+    TranslationDiff::Providers::Google.new(api).translate(%w[one], from: :en, to: :ru, format: :text)
 
-    assert_equal :html, api.calls.first.last[:format]
+    assert_equal :text, api.calls.first.last[:format]
   end
 
   # A configuration written against DeepL says "EN"; Google's codes are

--- a/test/translation_diff/tokenizer_test.rb
+++ b/test/translation_diff/tokenizer_test.rb
@@ -106,6 +106,40 @@ class TokenizerTest < Minitest::Test
         ["<?xml:namespace ns=\"urn:office\" ?>", :markup]
       ]
     ],
+    # Ox reports a comment, a doctype and a CDATA section as their own SAX
+    # events. Each one needs a handler: without it the bytes it covers are
+    # attributed to no token at all and vanish from the rebuilt string.
+    "an_html_comment" => [
+      "<!-- note --> Visible text.",
+      [
+        ["<!-- note -->", :markup],
+        [" Visible text.", :text]
+      ]
+    ],
+    "a_doctype" => [
+      "<!DOCTYPE html><p>Body text.</p>",
+      [
+        ["<!DOCTYPE html><p>", :markup],
+        ["Body text.", :text],
+        ["</p>", :markup]
+      ]
+    ],
+    "a_cdata_section" => [
+      "Before.<![CDATA[raw & unparsed]]>After.",
+      [
+        ["Before.", :text],
+        ["<![CDATA[raw & unparsed]]>", :markup],
+        ["After.", :text]
+      ]
+    ],
+    "a_comment_between_two_sentences" => [
+      "First sentence. <!-- aside --> Second sentence.",
+      [
+        ["First sentence. ", :text],
+        ["<!-- aside -->", :markup],
+        [" Second sentence.", :text]
+      ]
+    ],
     "sentences_separated_by_blank_lines" => [
       "Набор «Солнечная механика» от 4М — это 6 экспериментов." \
       "\n\nЮному изобретателю предстоит воочию посмотреть на чудеса.",


### PR DESCRIPTION
Two fixes, both found by probing the tokenizer against real-world HTML.

## 1. Comments, doctypes and CDATA sections were being destroyed

`Tokenizer` declared handlers for elements, text and processing instructions, but not for the `comment`, `doctype` and `cdata` events Ox also reports. Each carries its own byte position, and the tokenizer works by slicing the source between consecutive positions — so an event with no handler leaves its bytes attributed to no token.

```ruby
"<!-- note --> Visible text."
→ [[" Visible text.", :text]]                      # comment gone

"First sentence. <!-- aside --> Second sentence."
→ [["First sentence. ", :text],
   ["<!", :text],
   ["-- aside --> Second sentence.", :text]]        # comment translated
```

The first drops the comment. The second is worse: `<!` leaks into a translatable token and the comment's contents go to the provider as prose — paying for the characters, and standing a fair chance of an internal note coming back translated, in place, inside what used to be a comment.

The three share one handler because they share a shape: each opens and closes in a single event, so none may be pushed onto `@context` the way an element is. Inside a notranslate region each becomes `:text`, for the same reason element markup does there.

Not fixed here, because it is Ox's own rather than ours: a bare `<` in text (`"if a < b"`) still swallows the rest of the line into markup. Ox is a tolerant XML parser; the HTML5 rule that `<` before a non-letter is literal text is not available to it. That needs a different lexer, not a callback.

## 2. The Google provider asked for plain text

It defaulted to `format: :text` on the reasoning that anything reaching a provider has already been through the Tokenizer and is therefore plain. That reasoning was wrong: a notranslate span is handed over whole, tags included, and entities such as `&amp;` stay in the emitted text.

Verified against the live API:

```
"<span class='notranslate'>Bold Mountain</span> is a good place."
format: text  ->  "Болд Маунтин — хорошее место."
format: html  ->  "<span class='notranslate'>Bold Mountain</span> — хорошее место."
```

Under `text`, notranslate does not work at all — the protected name is transliterated and the span's markup destroyed. `html` is Google's own default and what this gem sent for its whole life before the provider seam existed.

The cost is that Google escapes its output: a literal apostrophe returns as `&#39;`. Inside the HTML fragment these values usually are, that renders correctly; inside a value with no markup it is noise, and such a caller can pass `format: :text` per call.

## Verification

- 227 runs, 490 assertions, 0 failures, on seeds 1, 99 and 4242. RuboCop clean on 52 files.
- Live end-to-end against a real key:

```
"<span class='notranslate'>Bold Mountain</span> is a good place."
→ "<span class='notranslate'>Bold Mountain</span> — хорошее место."

"<!-- internal note --> Visible text here."
→ "<!-- internal note --> Здесь отображается видимый текст."
```