### PR TITLE
fix: send HTML tag handling to DeepL so notranslate works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,15 @@ described below. Everything here is relative to `deepl_diff` 2.2.0.
 
 ### Fixed
 
+- `notranslate` works with DeepL. The provider sent no `tag_handling`, and
+  per DeepL's documentation "tags are treated as regular text" without it,
+  so a span the tokenizer had marked as protected was translated anyway.
+  The provider now sends `tag_handling: :html` and
+  `tag_handling_version: "v2"`, both overridable per call. This has been
+  broken since the gem moved from Google to DeepL: `tag_handling` appears
+  nowhere in the repository's history before this change. It failed
+  quietly, because DeepL leaves the tags themselves alone either way and
+  only the protected content came back changed.
 - Comments, doctypes and CDATA sections survive a translation. `Tokenizer`
   declared no handler for those three Ox SAX events, so the bytes each one
   covered belonged to no token: a leading `<!-- ... -->` or `<!DOCTYPE html>`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,29 @@ would serve, the real service's entries. Give such a configuration its own
 here on purpose: changing its shape invalidates every entry already cached,
 everywhere, at once.
 
+### The DeepL provider
+
+`config.provider = :deepl` is the default. It sends `tag_handling: :html`
+and `tag_handling_version: "v2"` with every translation, because what
+reaches a provider is not plain text: a `notranslate` span arrives whole,
+tags included. DeepL honours `class="notranslate"` and `translate="no"`
+only under HTML tag handling -- without it, in DeepL's own words, "tags are
+treated as regular text".
+
+That failure was a quiet one, worth knowing about if you translated with an
+older version: DeepL leaves the tags themselves alone either way, so the
+markup looks untouched and only the protected content comes back changed.
+
+```
+"<span class='notranslate'>Bold Mountain</span> is a good place."
+no tag handling ->  "<span class='notranslate'>Болд-Маунтин</span> — отличное место."
+tag_handling    ->  "<span class='notranslate'>Bold Mountain</span> — это хорошее место."
+```
+
+Both values are overridable per call, as any provider option is. Under HTML
+tag handling DeepL defaults `split_sentences` to `nonewlines`; this library
+sends one sentence at a time, so that changes nothing.
+
 ### The Google provider
 
 `config.provider = :google` translates through Cloud Translation v2 (Basic).

--- a/lib/translation_diff/providers/deepl.rb
+++ b/lib/translation_diff/providers/deepl.rb
@@ -16,6 +16,24 @@ class TranslationDiff::Providers::DeepL
   MAX_REQUEST_SIZE = 1700
   MAX_BATCH_SIZE = 300
 
+  # What arrives here is not plain text, despite having been through the
+  # Tokenizer. A notranslate span is handed over whole, tags included --
+  # that is how the tokenizer marks content the provider must leave alone.
+  # DeepL honours `class="notranslate"` (and `translate="no"`) only under
+  # HTML tag handling; without it, in DeepL's own words, "tags are treated
+  # as regular text". The failure is quiet, because DeepL leaves the tags
+  # themselves alone either way and only the protected content changes:
+  #
+  #   "<span class='notranslate'>Bold Mountain</span> is a good place."
+  #   no tag_handling -> "<span class='notranslate'>Болд-Маунтин</span> — отличное место."
+  #   tag_handling    -> "<span class='notranslate'>Bold Mountain</span> — это хорошее место."
+  #
+  # v2 is the tag handling algorithm DeepL's documentation recommends.
+  # Note that under HTML tag handling DeepL defaults `split_sentences` to
+  # `nonewlines`; this library sends one sentence at a time, so that
+  # changes nothing here.
+  DEFAULT_OPTIONS = { tag_handling: :html, tag_handling_version: "v2" }.freeze
+
   def self.configuration_options = %i[deepl_api_key deepl_host]
 
   # `config.logger` is deliberately NOT forwarded into DeepL::Configuration.
@@ -44,7 +62,7 @@ class TranslationDiff::Providers::DeepL
   end
 
   def translate(texts, from:, to:, **options)
-    Array(request(texts, from, to, options)).map(&:text)
+    Array(request(texts, from, to, DEFAULT_OPTIONS.merge(options))).map(&:text)
   end
 
   def detect(text)

--- a/test/translation_diff/providers/deepl_test.rb
+++ b/test/translation_diff/providers/deepl_test.rb
@@ -52,7 +52,29 @@ class DeepLProviderTest < Minitest::Test
 
     fake.translate(%w[one], from: :en, to: :ru, formality: :less)
 
-    assert_equal [[%w[one], :en, :ru, { formality: :less }]], fake.calls
+    assert_equal({ formality: :less }, fake.calls.first.last.slice(:formality))
+  end
+
+  # What reaches a provider is not plain text: Tokenizer hands a notranslate
+  # span over with its tags. DeepL honours `class="notranslate"` only under
+  # `tag_handling: html`; without it, per DeepL's own documentation, "tags
+  # are treated as regular text" -- and the protected content is translated
+  # while the tags survive, which is exactly the shape of bug nobody spots.
+  def test_translate_asks_for_html_tag_handling
+    fake = FakeDeepL.new
+
+    fake.translate(%w[one], from: :en, to: :ru)
+
+    assert_equal({ tag_handling: :html, tag_handling_version: "v2" },
+                 fake.calls.first.last.slice(:tag_handling, :tag_handling_version))
+  end
+
+  def test_translate_lets_the_caller_override_the_tag_handling
+    fake = FakeDeepL.new
+
+    fake.translate(%w[one], from: :en, to: :ru, tag_handling: :xml)
+
+    assert_equal :xml, fake.calls.first.last[:tag_handling]
   end
 
   def test_detect_downcases_the_language


### PR DESCRIPTION
The DeepL provider sent no `tag_handling`. Per [DeepL's documentation](https://developers.deepl.com/docs/translate/translating-html), "Without `tag_handling`, tags are treated as regular text" — and `class="notranslate"`, which DeepL does honour, is honoured only under HTML tag handling.

The tokenizer hands a notranslate span to the provider whole, tags included, precisely so the provider can leave its contents alone. It could not.

## Confirmed against the live API

```
"<span class='notranslate'>Bold Mountain</span> is a good place."

no tag_handling ->  "<span class='notranslate'>Болд-Маунтин</span> — отличное место."
tag_handling    ->  "<span class='notranslate'>Bold Mountain</span> — это хорошее место."
```

Note what the first line does: the span's tags survive untouched and only the protected name is translated. Nothing about the output looks wrong — which is why this went unnoticed. `tag_handling` appears nowhere in this repository's history, so notranslate has not worked for a single day since the gem moved from Google to DeepL.

## The change

`tag_handling: :html` and `tag_handling_version: "v2"` (the algorithm DeepL's docs recommend) are sent as defaults a caller can override, the way every other provider option works.

Under HTML tag handling DeepL defaults `split_sentences` to `nonewlines`; this library sends one sentence per value, so that changes nothing here.

Detection is left alone: it sends a 100-character sample that may end mid-tag, and DeepL never strictly parses HTML anyway.

## Verification

- 229 runs, 492 assertions, 0 failures, on seeds 1, 99 and 4242. RuboCop clean on 52 files.
- Live end-to-end through the gem:

```
"<span class='notranslate'>Bold Mountain</span> is a good place."
→ "<span class='notranslate'>Bold Mountain</span> — это хорошее место."

"<!-- internal note --> Visible text here."
→ "<!-- internal note --> Здесь отображается текст."

"Salt &amp; pepper. Fine."
→ "Соль и перец. Хорошо."
```